### PR TITLE
Feature/use built in types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,27 @@ Notes:
 
 ---
 
+## Release [1.7.0] - 2025-08-19
+
+### Changed
+
+- Migrated to built-in RTL types for arrays of strings:
+  - Replaced custom `TMatchStrings` with `Types.TStringDynArray` across the public API, helpers, tests, and documentation.
+  - Helper method signatures updated accordingly, e.g., `JoinWith(const Strings: TStringDynArray)`.
+- Documentation updated (README and Cheat Sheet) to reflect the new types and signatures.
+
+### Migration Notes
+
+- If you referenced `TMatchStrings`, switch to `Types.TStringDynArray`.
+- Ensure `Types` is in your unit's `uses` clause when working with `TStringDynArray`.
+- Instance-style `JoinWith` remains the recommended usage: `', '.JoinWith(Arr)`.
+
+### Fixed
+
+- Minor consistency fixes in examples and comments related to split/join and n-grams.
+
+---
+
 ## Release [1.6.0] - 2025-08-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ end;
 ```pascal
 var
   Matches: TMatchesResults;
-  AllMatches: TMatchStrings;
+  AllMatches: TStringDynArray;
   i: Integer;
 begin
   // Built-in validators
@@ -457,7 +457,7 @@ end;
 var
   WordCount: Integer;
   Readability: Double;
-  NGrams: TMatchStrings;
+  NGrams: TStringDynArray;
   i: Integer;
 begin
   // Basic text statistics
@@ -480,7 +480,7 @@ end;
 
 ```pascal
 var
-  Parts: TMatchStrings;
+  Parts: TStringDynArray;
   Joined: string;
   i: Integer;
 begin

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Documentation](https://img.shields.io/badge/Docs-Available-brightgreen.svg)](docs/)
 [![Tests](https://img.shields.io/badge/Tests-Passing-brightgreen.svg)](tests/)
 [![Status](https://img.shields.io/badge/Status-Ready%20to%20Weave-brightgreen.svg)]()
-[![Version](https://img.shields.io/badge/Version-1.6.0-blueviolet.svg)]()
+[![Version](https://img.shields.io/badge/Version-1.7.0-blueviolet.svg)]()
 
 
 <p align="center">

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -21,7 +21,7 @@ begin
   S := '  Mixed Case  '.Trim.ToUpper;   // Chaining: 'MIXED CASE'
   if 'ABC123'.MatchesPattern('^[A-Z]{3}\d{3}$') then ; // True (regex via helper)
   // Split and Join via helpers
-  // Note: Split returns TMatchStrings; JoinWith uses Self as the delimiter
+  // Note: Split returns TStringDynArray; JoinWith uses Self as the delimiter
   S := ','.JoinWith('a,b,,c'.Split(',', 0, True)); // 'a,b,c'
 end;
 ```

--- a/packages/lazarus/stringkit_fp.lpk
+++ b/packages/lazarus/stringkit_fp.lpk
@@ -21,7 +21,7 @@
         <CustomOptions Value="-FcUTF8"/>
       </Other>
     </CompilerOptions>
-    <Description Value="Comprehensive string manipulation library providing 90+ static methods for validation, case conversion, pattern matching, fuzzy algorithms, phonetic matching, text analysis, and web encoding. Zero external dependencies - uses only Free Pascal RTL."/>
+    <Description Value="Comprehensive string manipulation library providing 70+ static methods and string helpers for validation, case conversion, pattern matching, fuzzy algorithms, phonetic matching, text analysis, and web encoding. Zero external dependencies - uses only Free Pascal RTL."/>
     <License Value="MIT License
 
 Copyright (c) 2025 ikelaiah
@@ -43,7 +43,7 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE. "/>
-    <Version Major="1" Minor="6"/>
+    <Version Major="1" Minor="7"/>
     <Files>
       <Item>
         <Filename Value="..\..\src\StringKit.pas"/>

--- a/src/StringKit.pas
+++ b/src/StringKit.pas
@@ -5,7 +5,7 @@ unit StringKit;
 interface
 
 uses
-  Classes, SysUtils, RegExpr, StrUtils, Math, DateUtils, base64;
+  Classes, SysUtils, Types, RegExpr, StrUtils, Math, DateUtils, base64;
 
 type
   { TStringMatch
@@ -26,12 +26,7 @@ type
   }
   TMatchesResults = array of TStringMatch;
 
-  {
-   TMatchStrings
-   -------------
-   Array of strings for general string list operations or extracted matches.
-  }
-  TMatchStrings = array of string;
+  
 
   { TStringKit
     ----------
@@ -474,14 +469,14 @@ type
       @param Text The string to search within.
       @param Pattern The regular expression pattern to match.
       
-      @returns A dynamic array of strings (TMatchStrings), where each element is a matched substring.
+      @returns A dynamic array of strings (TStringDynArray), where each element is a matched substring.
                Returns an empty array if no matches are found.
       
       @warning Relies on ExtractMatches internally. Regular expressions can be computationally
                expensive. Returns an empty array for invalid patterns or no matches.
       
       @example
-        // Assuming Result is declared as TMatchStrings
+        // Assuming Result is declared as TStringDynArray
         Result := ExtractAllMatches('Emails: a@b.com, c@d.net.', '\w+@\w+\.\w+');
         // Result[0]: 'a@b.com'
         // Result[1]: 'c@d.net'
@@ -489,7 +484,7 @@ type
         Result := ExtractAllMatches('No emails here', '\w+@\w+\.\w+');
         // Length(Result) = 0
     }
-    class function ExtractAllMatches(const Text, Pattern: string): TMatchStrings; static;
+    class function ExtractAllMatches(const Text, Pattern: string): TStringDynArray; static;
     
     {
       @description Tests if a string fully matches a given regular expression pattern.
@@ -586,7 +581,7 @@ type
       
       @param AText The text to split into words.
       
-      @returns A dynamic array of strings (TMatchStrings), where each element is a word.
+      @returns A dynamic array of strings (TStringDynArray), where each element is a word.
                Returns an empty array if the text contains no alphanumeric characters.
       
       @warning Considers only ASCII letters and digits as part of words. Punctuation attached
@@ -594,7 +589,7 @@ type
                Multiple non-alphanumeric characters between words result in a single split.
       
       @example
-        // Assuming Result is declared as TMatchStrings
+        // Assuming Result is declared as TStringDynArray
         Result := GetWords('Hello, world! How are you?');
         // Result[0]: 'Hello'
         // Result[1]: 'world'
@@ -610,7 +605,7 @@ type
         Result := GetWords('---');
         // Length(Result) = 0
     }
-    class function GetWords(const AText: string): TMatchStrings; static;
+    class function GetWords(const AText: string): TStringDynArray; static;
     
     {
       @description Counts the number of non-overlapping occurrences of a substring within a text.
@@ -1507,7 +1502,7 @@ type
       @usage Use to combine multiple string pieces into one, for example, creating a comma-separated list
              or reconstructing a sentence from words.
       
-      @param Strings The array of strings (TMatchStrings) to join.
+      @param Strings The array of strings (TStringDynArray) to join.
       @param Delimiter The string to insert between each element of the array.
       
       @returns The concatenated string. Returns an empty string if the input array is empty.
@@ -1516,7 +1511,7 @@ type
       @warning None identified.
       
       @example
-        // Assuming Arr is TMatchStrings
+        // Assuming Arr is TStringDynArray
         Arr := ['apple', 'banana', 'cherry'];
         Result := Join(Arr, ', '); // Returns: 'apple, banana, cherry'
         
@@ -1526,7 +1521,7 @@ type
         SetLength(Arr, 0);
         Result := Join(Arr, ',');   // Returns: ''
     }
-    class function Join(const Strings: TMatchStrings; const Delimiter: string): string; static;
+    class function Join(const Strings: TStringDynArray; const Delimiter: string): string; static;
     
     {
       @description Splits a string into an array of substrings based on a specified delimiter.
@@ -1543,7 +1538,7 @@ type
       @param RemoveEmptyEntries If True, empty strings resulting from the split (e.g., from
                               consecutive delimiters) are excluded from the result array. Default is False.
       
-      @returns A dynamic array of strings (TMatchStrings) containing the substrings.
+      @returns A dynamic array of strings (TStringDynArray) containing the substrings.
       
       @warning The delimiter itself is not included in the results. If Text is empty, returns an array
                containing a single empty string unless RemoveEmptyEntries is True. If Delimiter is empty,
@@ -1551,7 +1546,7 @@ type
                The current implementation seems to handle empty delimiter by finding it at Pos 1, potentially leading to issues. Let's assume Delimiter is non-empty.
       
       @example
-        // Assuming Result is TMatchStrings
+        // Assuming Result is TStringDynArray
         Result := Split('a,b,c', ','); // Returns: ['a', 'b', 'c']
         Result := Split('a,,c', ','); // Returns: ['a', '', 'c']
         Result := Split('a,,c', ',', 0, True); // Returns: ['a', 'c'] (RemoveEmptyEntries=True)
@@ -1561,7 +1556,7 @@ type
         Result := Split('', ',', 0, True); // Returns: []
         Result := Split('test', 'x'); // Returns: ['test']
     }
-    class function Split(const Text, Delimiter: string; MaxSplit: Integer = 0; RemoveEmptyEntries: Boolean = False): TMatchStrings; static;
+    class function Split(const Text, Delimiter: string; MaxSplit: Integer = 0; RemoveEmptyEntries: Boolean = False): TStringDynArray; static;
     
     { -------------------- Phonetic Algorithms -------------------- }
     
@@ -1700,7 +1695,7 @@ type
       @param Text The text to process.
       @param N The size of the n-gram (e.g., 2 for bigrams, 3 for trigrams). Must be > 0.
       
-      @returns A dynamic array of strings (TMatchStrings), where each string is an n-gram
+      @returns A dynamic array of strings (TStringDynArray), where each string is an n-gram
                with words separated by single spaces. Returns an empty array if N <= 0,
                Text is empty, or Text contains fewer than N words.
       
@@ -1708,7 +1703,7 @@ type
                N-grams are simple space-separated concatenations of the identified words.
       
       @example
-        // Assuming Result is TMatchStrings
+        // Assuming Result is TStringDynArray
         Result := GenerateNGrams('the quick brown fox', 2); // Bigrams
         // Result[0]: 'the quick'
         // Result[1]: 'quick brown'
@@ -1728,7 +1723,7 @@ type
         Result := GenerateNGrams('test', 0); // N <= 0
         // Length(Result) = 0
     }
-    class function GenerateNGrams(const Text: string; N: Integer): TMatchStrings; static;
+    class function GenerateNGrams(const Text: string; N: Integer): TStringDynArray; static;
     
     { -------------------- Encoding/Decoding Functions -------------------- }
     
@@ -2216,7 +2211,7 @@ begin
   end;
 end;
 
-class function TStringKit.ExtractAllMatches(const Text, Pattern: string): TMatchStrings;
+class function TStringKit.ExtractAllMatches(const Text, Pattern: string): TStringDynArray;
 var
   Matches: TMatchesResults;
   I: Integer;
@@ -2261,7 +2256,7 @@ begin
   Result := StringReplace(Text, OldText, NewText, [rfReplaceAll]);
 end;
 
-class function TStringKit.GetWords(const AText: string): TMatchStrings;
+class function TStringKit.GetWords(const AText: string): TStringDynArray;
 var
   WordList: TStringList;
   I: Integer;
@@ -2650,7 +2645,7 @@ end;
 
 class function TStringKit.ToCamelCase(const Text: string): string;
 var
-  Words: TMatchStrings;
+  Words: TStringDynArray;
   I: Integer;
   Word: string;
 begin
@@ -2675,7 +2670,7 @@ end;
 
 class function TStringKit.ToPascalCase(const Text: string): string;
 var
-  Words: TMatchStrings;
+  Words: TStringDynArray;
   I: Integer;
   Word: string;
 begin
@@ -2693,7 +2688,7 @@ end;
 
 class function TStringKit.ToSnakeCase(const Text: string): string;
 var
-  Words: TMatchStrings;
+  Words: TStringDynArray;
   I: Integer;
 begin
   Words := GetWords(Text);
@@ -2709,7 +2704,7 @@ end;
 
 class function TStringKit.ToKebabCase(const Text: string): string;
 var
-  Words: TMatchStrings;
+  Words: TStringDynArray;
   I: Integer;
 begin
   Words := GetWords(Text);
@@ -2971,7 +2966,7 @@ begin
     Result := '-' + Result;
 end;
 
-class function TStringKit.Join(const Strings: TMatchStrings; const Delimiter: string): string;
+class function TStringKit.Join(const Strings: TStringDynArray; const Delimiter: string): string;
 var
   I: Integer;
 begin
@@ -2986,7 +2981,7 @@ begin
     Result := Result + Delimiter + Strings[I];
 end;
 
-class function TStringKit.Split(const Text, Delimiter: string; MaxSplit: Integer = 0; RemoveEmptyEntries: Boolean = False): TMatchStrings;
+class function TStringKit.Split(const Text, Delimiter: string; MaxSplit: Integer = 0; RemoveEmptyEntries: Boolean = False): TStringDynArray;
 var
   SplitList: TStringList;
   I, SplitCount: Integer;
@@ -3356,7 +3351,7 @@ end;
 
 class function TStringKit.CountWords(const Text: string): Integer;
 var
-  Words: TMatchStrings;
+  Words: TStringDynArray;
 begin
   Words := GetWords(Text);
   Result := Length(Words);
@@ -3364,7 +3359,7 @@ end;
 
 class function TStringKit.FleschKincaidReadability(const Text: string): Double;
 var
-  Words: TMatchStrings;
+  Words: TStringDynArray;
   Sentences, Syllables, I, WordCount: Integer;
   Word: string;
 begin
@@ -3414,9 +3409,9 @@ begin
     Result := 100;
 end;
 
-class function TStringKit.GenerateNGrams(const Text: string; N: Integer): TMatchStrings;
+class function TStringKit.GenerateNGrams(const Text: string; N: Integer): TStringDynArray;
 var
-  Words: TMatchStrings;
+  Words: TStringDynArray;
   NGramList: TStringList;
   I, J, NGramCount: Integer;
   NGram: string;

--- a/src/StringKitHelper.pas
+++ b/src/StringKitHelper.pas
@@ -26,7 +26,7 @@ unit StringKitHelper;
 interface
 
 uses
-  Classes, SysUtils, StringKit, RegExpr;
+  Classes, SysUtils, Types, StringKit, RegExpr;
 
 // Feature toggles
 // If no specific feature macro is provided, enable all by default.

--- a/src/inc/Match.impl.inc
+++ b/src/inc/Match.impl.inc
@@ -3,7 +3,7 @@ begin
   Result := TStringKit.ExtractMatches(Self, Pattern);
 end;
 
-function TStringHelperEx.ExtractAllMatches(const Pattern: string): TMatchStrings;
+function TStringHelperEx.ExtractAllMatches(const Pattern: string): TStringDynArray;
 begin
   Result := TStringKit.ExtractAllMatches(Self, Pattern);
 end;
@@ -23,7 +23,7 @@ begin
   Result := TStringKit.ReplaceText(Self, OldText, NewText);
 end;
 
-function TStringHelperEx.GetWords: TMatchStrings;
+function TStringHelperEx.GetWords: TStringDynArray;
 begin
   Result := TStringKit.GetWords(Self);
 end;

--- a/src/inc/Match.intf.inc
+++ b/src/inc/Match.intf.inc
@@ -1,10 +1,10 @@
 // String matching and extraction
 function ExtractMatches(const Pattern: string): TMatchesResults; inline;
-function ExtractAllMatches(const Pattern: string): TMatchStrings; inline;
+function ExtractAllMatches(const Pattern: string): TStringDynArray; inline;
 function MatchesPattern(const Pattern: string): Boolean; inline;
 function ReplaceRegEx(const Pattern, Replacement: string): string; inline;
 function ReplaceText(const OldText, NewText: string): string; inline;
-function GetWords: TMatchStrings; inline;
+function GetWords: TStringDynArray; inline;
 function CountSubString(const SubStr: string): Integer; inline;
 function Contains(const SubStr: string): Boolean; inline;
 function StartsWith(const Prefix: string): Boolean; inline;

--- a/src/inc/Phonetic.impl.inc
+++ b/src/inc/Phonetic.impl.inc
@@ -18,7 +18,7 @@ begin
   Result := TStringKit.FleschKincaidReadability(Self);
 end;
 
-function TStringHelperEx.GenerateNGrams(N: Integer): TMatchStrings;
+function TStringHelperEx.GenerateNGrams(N: Integer): TStringDynArray;
 begin
   Result := TStringKit.GenerateNGrams(Self, N);
 end;

--- a/src/inc/Phonetic.intf.inc
+++ b/src/inc/Phonetic.intf.inc
@@ -3,4 +3,4 @@ function Soundex: string; inline;
 function Metaphone: string; inline;
 function CountWords: Integer; inline;
 function FleschKincaidReadability: Double; inline;
-function GenerateNGrams(N: Integer): TMatchStrings; inline;
+function GenerateNGrams(N: Integer): TStringDynArray; inline;

--- a/src/inc/Split.impl.inc
+++ b/src/inc/Split.impl.inc
@@ -1,9 +1,9 @@
-function TStringHelperEx.JoinWith(const Strings: TMatchStrings): string;
+function TStringHelperEx.JoinWith(const Strings: TStringDynArray): string;
 begin
   Result := TStringKit.Join(Strings, Self);
 end;
 
-function TStringHelperEx.Split(const Delimiter: string; MaxSplit: Integer; RemoveEmptyEntries: Boolean): TMatchStrings;
+function TStringHelperEx.Split(const Delimiter: string; MaxSplit: Integer; RemoveEmptyEntries: Boolean): TStringDynArray;
 begin
   Result := TStringKit.Split(Self, Delimiter, MaxSplit, RemoveEmptyEntries);
 end;

--- a/src/inc/Split.intf.inc
+++ b/src/inc/Split.intf.inc
@@ -1,3 +1,3 @@
 // String splitting and joining
-function JoinWith(const Strings: TMatchStrings): string; inline;
-function Split(const Delimiter: string; MaxSplit: Integer = 0; RemoveEmptyEntries: Boolean = False): TMatchStrings; inline;
+function JoinWith(const Strings: TStringDynArray): string; inline;
+function Split(const Delimiter: string; MaxSplit: Integer = 0; RemoveEmptyEntries: Boolean = False): TStringDynArray; inline;

--- a/tests/StringKit.Test.pas
+++ b/tests/StringKit.Test.pas
@@ -5,12 +5,11 @@ unit StringKit.Test;
 interface
 
 uses
-  Classes, SysUtils, DateUtils, fpcunit, testregistry,
+  Classes, SysUtils, Types, DateUtils, fpcunit, testregistry,
   StringKit;
 
 type
   TStringArray = array of string;
-  TMatchStrings = array of string;
 
 type
 
@@ -816,7 +815,7 @@ end;
 
 procedure TStringTests.Test54_Join;
 var
-  Arr1, Arr2, Arr3, EmptyArr: TMatchStrings;
+  Arr1, Arr2, Arr3, EmptyArr: TStringDynArray;
 begin
   SetLength(Arr1, 3);
   Arr1[0] := 'one';
@@ -851,7 +850,7 @@ end;
 
 procedure TStringTests.Test55_Split;
 var
-  Result: TMatchStrings;
+  Result: TStringDynArray;
 begin
   // Basic splitting
   Result := TStringKit.Split('one,two,three', ',');
@@ -958,7 +957,7 @@ end;
 
 procedure TStringTests.Test60_GenerateNGrams;
 var
-  Result: TMatchStrings;
+  Result: TStringDynArray;
 begin
   // Bigrams
   Result := TStringKit.GenerateNGrams('This is a test', 2);

--- a/tests/StringKitHelper.Test.pas
+++ b/tests/StringKitHelper.Test.pas
@@ -14,11 +14,10 @@ unit StringKitHelper.Test;
 interface
 
 uses
-  Classes, SysUtils, fpcunit, testregistry, StringKit, StringKitHelper;
+  Classes, SysUtils, Types, fpcunit, testregistry, StringKit, StringKitHelper;
 
 type
   TStringArray = array of string;
-  TMatchStrings = array of string;
 
 type
   { TStringHelperTests }
@@ -721,7 +720,7 @@ end;
 
 procedure TStringHelperTests.Test60_GenerateNGrams;
 var
-  Result: TMatchStrings;
+  Result: TStringDynArray;
 begin
   // Bigrams
   Result := 'This is a test'.GenerateNGrams(2);


### PR DESCRIPTION
Description

- Migrated to built-in RTL types.
- Replaced custom `TMatchStrings` with `Types.TStringDynArray` across public API, helper signatures, and documentation.
- Added entry for 1.7.0 with migration notes in the CHANGELOG.md.

Fixes # (issue)
- #2 

Type of change

- [x] Documentation update
- [x] Other: Refactor (non-breaking) to use built-in RTL types

Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A for this refactor)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)

Testing

- Build: compiled successfully.
- Runner: executed tests with TestRunner.
- Command (in tests/):
```bash
./TestRunner.exe -a --format=plain
```
- Result: all tests passed (144/144).
