### PR TITLE
Enable GitHub Pages publishing

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,6 +48,8 @@ jobs:
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        with:
+          enablement: true
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4


### PR DESCRIPTION
## Summary

Enables GitHub Pages from the documentation workflow when no Pages site has previously been configured.

## Root cause

The first post-merge documentation workflow built and validated the site successfully, then failed because the repository had no Pages site. `actions/configure-pages` now receives `enablement: true`.

## Verification

- Workflow YAML parsed successfully.
- Documentation builder and built-site checker regression tests pass.
- No intentional API changes.