### PR TITLE
Add generated documentation homepage banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ python tools/check_built_docs.py --site build/docs-site
 
 The existing library suite is compiled and run by GitHub Actions on Ubuntu and Windows. See [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidance and [CHANGELOG.md](CHANGELOG.md) for release history.
 
+## Documentation site
+
+The generated documentation homepage is configured in [`docs/layout.json`](docs/layout.json). Its optional `homepage.banner` block names an SVG kept in the repository and supplies the image's alternative text. The generator copies that SVG to the built site's `assets/homepage-banner.svg` and renders it on the homepage; do not edit generated `index.html` files or add the banner to Markdown pages manually.
+
 ## License
 
 [MIT](LICENSE.md)

--- a/docs/layout.json
+++ b/docs/layout.json
@@ -53,6 +53,10 @@
   ],
   "homepage": {
     "tagline": "A modern string toolkit for Free Pascal and Lazarus.",
+    "banner": {
+      "project_path": "assets/stringkit-fp-banner.svg",
+      "alt": "StringKit-FP yarn-inspired banner"
+    },
     "actions": [
       { "label": "Get Started", "path": "start/beginner-guide.md" },
       { "label": "Browse Recipes", "path": "start/recipes.md" },

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -57,12 +57,19 @@ class ProjectLink:
 
 
 @dataclass(frozen=True)
+class HomepageBanner:
+    project_path: str
+    alt: str
+
+
+@dataclass(frozen=True)
 class DocumentationLayout:
     site_title: str
     description: str
     navigation: tuple[NavigationSection, ...]
     project_links: tuple[ProjectLink, ...]
     homepage: dict[str, object]
+    banner: HomepageBanner | None = None
     legacy: bool = False
 
     @property
@@ -177,6 +184,15 @@ def safe_document_path(value: object, label: str) -> str:
     return path.as_posix()
 
 
+def safe_project_asset_path(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{label} must be a non-empty slash-separated path")
+    path = Path(value)
+    if path.is_absolute() or path.drive or ".." in path.parts or path.suffix.lower() != ".svg":
+        raise ValueError(f"{label} must name an SVG file within the repository")
+    return path.as_posix()
+
+
 def legacy_navigation(source: Path) -> tuple[NavigationSection, ...]:
     grouped: dict[str, list[NavigationPage]] = {"Getting Started": [], "Guides": [], "Reference": []}
     for document in sorted(source.rglob("*.md")):
@@ -270,7 +286,24 @@ def load_layout(source: Path, config: SiteConfig) -> DocumentationLayout:
         homepage = data.get("homepage", {})
         if not isinstance(homepage, dict):
             raise ValueError("homepage must be an object")
-        return DocumentationLayout(site_title, description, tuple(navigation), tuple(project_links), homepage)
+        banner = homepage.get("banner")
+        homepage_banner = None
+        if banner is not None:
+            if not isinstance(banner, dict):
+                raise ValueError("homepage banner must be an object")
+            project_path = safe_project_asset_path(banner.get("project_path"), "homepage banner project_path")
+            alt = banner.get("alt")
+            if not isinstance(alt, str) or not alt.strip():
+                raise ValueError("homepage banner alt must be a non-empty string")
+            asset = (source.parent / project_path).resolve()
+            try:
+                asset.relative_to(source.parent.resolve())
+            except ValueError as exc:
+                raise ValueError("homepage banner project_path must stay within the repository") from exc
+            if not asset.is_file():
+                raise ValueError(f"homepage banner asset does not exist: {project_path}")
+            homepage_banner = HomepageBanner(project_path, alt.strip())
+        return DocumentationLayout(site_title, description, tuple(navigation), tuple(project_links), homepage, homepage_banner)
     except (OSError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise ValueError(f"invalid documentation layout {layout_path}: {exc}") from exc
 
@@ -496,7 +529,12 @@ def homepage_content(layout: DocumentationLayout, page: Path, output: Path) -> s
                 continue
             cards.append(f'<a class="home-card" href="{html.escape(href, quote=True)}"><span>{html.escape(card["eyebrow"])}</span><strong>{html.escape(card["title"])}</strong><p>{html.escape(card["description"])}</p></a>')
     hero = f'<section class="home-hero"><p class="eyebrow">Documentation</p><h1>{html.escape(layout.site_title.replace(" documentation", ""))}</h1><p>{tagline}</p><div class="hero-actions">{"".join(actions)}</div></section>'
-    return hero + (f'<section class="home-grid" aria-label="Documentation paths">{"".join(cards)}</section>' if cards else "")
+    cards_html = f'<section class="home-grid" aria-label="Documentation paths">{"".join(cards)}</section>' if cards else ""
+    banner_html = ""
+    if layout.banner:
+        banner_url = relative_url(page.parent, output / "assets" / "homepage-banner.svg")
+        banner_html = f'<figure class="homepage-banner"><img src="{html.escape(banner_url, quote=True)}" alt="{html.escape(layout.banner.alt, quote=True)}"></figure>'
+    return hero + cards_html + banner_html
 
 
 def remove_first_heading(body: str) -> str:
@@ -536,13 +574,15 @@ def prepare_output(output: Path, release: str) -> None:
     output.mkdir(parents=True, exist_ok=True); marker.write_text(release + "\n", encoding="utf-8")
 
 
-def copy_assets(output: Path) -> None:
+def copy_assets(output: Path, project_root: Path, layout: DocumentationLayout) -> None:
     assets = output / "assets"; assets.mkdir()
     for name in ("site.css", "site.js"):
         source = DOC_ASSETS / name
         if not source.is_file():
             raise ValueError(f"missing documentation asset: {source}")
         shutil.copy2(source, assets / name)
+    if layout.banner:
+        shutil.copy2(project_root / layout.banner.project_path, assets / "homepage-banner.svg")
 
 
 def write_landing_page(site_root: Path, config: SiteConfig) -> None:
@@ -571,7 +611,7 @@ def build_site(source: Path, output: Path, site_root: Path, versions_path: Path,
     documents = sorted(source.rglob("*.md"))
     if not documents:
         raise ValueError(f"no Markdown documents found in {source}")
-    validate_source_links(source, documents, source.parent); prepare_output(output, config.release); copy_assets(output)
+    validate_source_links(source, documents, source.parent); prepare_output(output, config.release); copy_assets(output, source.parent, layout)
     search_entries: list[dict[str, object]] = []; by_path = {item.path: item for item in layout.pages}
     for document in documents:
         relative = document.relative_to(source); relative_path = relative.as_posix(); page = output / relative.with_suffix(".html"); page.parent.mkdir(parents=True, exist_ok=True)

--- a/tools/docs_assets/site.css
+++ b/tools/docs_assets/site.css
@@ -352,6 +352,8 @@ blockquote p, .admonition p { margin: 0; }
 .home-card:hover { border-color: var(--accent); background: var(--surface-muted); color: var(--text); }
 .home-card strong { display: block; margin-top: 0.3rem; color: var(--heading); font-size: 1rem; }
 .home-card p { margin: 0.35rem 0 0; color: var(--text-muted); font-size: 0.86rem; }
+.homepage-banner { max-width: 72rem; margin: 0 0 2.5rem; overflow: hidden; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); box-shadow: var(--shadow); }
+.homepage-banner img { display: block; width: 100%; height: auto; }
 .homepage > h2 { margin-top: 2.5rem; }
 
 .external-link::after { margin-left: 0.18em; font-size: 0.72em; content: "↗"; }

--- a/tools/test_build_docs.py
+++ b/tools/test_build_docs.py
@@ -22,6 +22,11 @@ class BuildDocsTests(unittest.TestCase):
         output = root / "site" / "1.9.1"
         site_root = output.parent
         (source / "start").mkdir(parents=True)
+        (root / "assets").mkdir()
+        (root / "assets" / "banner.svg").write_text(
+            '<svg xmlns="http://www.w3.org/2000/svg"><title>StringKit-FP</title></svg>\n',
+            encoding="utf-8",
+        )
         (source / "index.md").write_text(
             "# StringKit-FP documentation\n\n"
             "Start with the [guide](start/guide.md).\n",
@@ -61,6 +66,10 @@ class BuildDocsTests(unittest.TestCase):
                     "project": [{"title": "GitHub repository", "url": "https://github.com/example/stringkit-fp"}],
                     "homepage": {
                         "tagline": "A modern string toolkit for Free Pascal and Lazarus.",
+                        "banner": {
+                            "project_path": "assets/banner.svg",
+                            "alt": "StringKit-FP yarn banner",
+                        },
                         "actions": [{"label": "Get Started", "path": "start/guide.md"}],
                     },
                 }
@@ -101,9 +110,16 @@ class BuildDocsTests(unittest.TestCase):
             self.assertIn('class="heading-anchor"', guide)
             self.assertIn('id="repeat-2"', guide)
             self.assertIn('id="version-select"', guide)
+            self.assertIn('class="homepage-banner"', index)
+            self.assertIn('src="assets/homepage-banner.svg"', index)
+            self.assertIn('alt="StringKit-FP yarn banner"', index)
             self.assertIn('<pre><code class="language-pascal">', guide)
             self.assertTrue((output / "assets" / "site.css").is_file())
             self.assertTrue((output / "assets" / "site.js").is_file())
+            self.assertEqual(
+                (source.parent / "assets" / "banner.svg").read_bytes(),
+                (output / "assets" / "homepage-banner.svg").read_bytes(),
+            )
             self.assertTrue((output / "search-index.json").is_file())
             self.assertTrue((output / "search-index.js").is_file())
             self.assertIn(':root[data-theme="dark"]', (output / "assets" / "site.css").read_text(encoding="utf-8"))
@@ -131,6 +147,17 @@ class BuildDocsTests(unittest.TestCase):
             )
 
             with self.assertRaisesRegex(ValueError, "unsafe link"):
+                build_site(source, output, site_root, source / "versions.json")
+
+    def test_rejects_a_missing_homepage_banner_asset(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source, output, site_root = self.write_fixture(Path(directory))
+            layout_path = source / "layout.json"
+            layout = json.loads(layout_path.read_text(encoding="utf-8"))
+            layout["homepage"]["banner"]["project_path"] = "assets/missing.svg"
+            layout_path.write_text(json.dumps(layout), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "homepage banner asset does not exist"):
                 build_site(source, output, site_root, source / "versions.json")
 
     def test_links_project_markdown_to_its_repository_source(self) -> None:


### PR DESCRIPTION
## Summary
- configure the homepage SVG banner in docs/layout.json
- copy and render the banner in generated documentation output
- add styling, validation, regression coverage, and contributor guidance

## Verification
- python tools/test_build_docs.py
- documentation tooling tests and checks
- built and validated both versioned documentation releases