### PR TITLE
Harden released documentation builds

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,11 +2,6 @@ name: Publish documentation
 
 on:
   workflow_dispatch:
-    inputs:
-      source_ref:
-        description: Source ref to publish as the current documentation release
-        required: true
-        default: main
   release:
     types: [published]
 
@@ -26,7 +21,7 @@ jobs:
       - name: Check out documentation source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || inputs.source_ref }}
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || 'main' }}
           fetch-depth: 0
 
       - name: Test documentation tooling
@@ -43,7 +38,7 @@ jobs:
 
       - name: Build versioned documentation
         run: |
-          python3 tools/build_all_docs.py --site-root site --offline-dir artifacts
+          python3 tools/build_all_docs.py --released --site-root site --offline-dir artifacts
           python3 tools/check_built_docs.py --site site
 
       - name: Configure GitHub Pages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Documentation
+
+- Added the generated StringKit-FP homepage SVG banner and refined its width for readable alignment with the documentation content.
+- Made published, versioned documentation rebuild every release from the immutable `source_ref` declared in `docs/versions.json`; development builds continue to preview the current checkout explicitly.
+
 ## [1.9.2] - 2026-08-22
 
 ### Documentation Experience

--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ The existing library suite is compiled and run by GitHub Actions on Ubuntu and W
 
 The generated documentation homepage is configured in [`docs/layout.json`](docs/layout.json). Its optional `homepage.banner` block names an SVG kept in the repository and supplies the image's alternative text. The generator copies that SVG to the built site's `assets/homepage-banner.svg` and renders it on the homepage; do not edit generated `index.html` files or add the banner to Markdown pages manually.
 
+Use `python tools/build_all_docs.py --development-current --site-root build/docs-site` to preview untagged documentation from the checkout. Published release documentation must use `--released`, which builds every declared version (including the current one) from the immutable `source_ref` in [`docs/versions.json`](docs/versions.json). The Pages workflow uses that released mode for both release events and manual rebuilds.
+
 ## License
 
 [MIT](LICENSE.md)

--- a/tools/build_all_docs.py
+++ b/tools/build_all_docs.py
@@ -34,7 +34,19 @@ def run_git(root: Path, arguments: list[str]) -> None:
         raise RuntimeError(f"git {' '.join(arguments)} failed:\n{result.stdout}{result.stderr}")
 
 
-def build_all(root: Path, site_root: Path, offline_dir: Path | None = None) -> int:
+def build_all(
+    root: Path,
+    site_root: Path,
+    offline_dir: Path | None = None,
+    development_current: bool = True,
+) -> int:
+    """Build all declared versions, optionally previewing the current checkout.
+
+    Development builds may use the checkout for the declared current release so
+    untagged documentation can be previewed. Released builds must set
+    ``development_current`` to ``False`` so every version, including current,
+    is read from its immutable ``source_ref``.
+    """
     root = root.resolve()
     versions_path = root / "docs" / "versions.json"
     current, versions = load_versions(versions_path)
@@ -45,7 +57,7 @@ def build_all(root: Path, site_root: Path, offline_dir: Path | None = None) -> i
             release = entry["release"]
             source_root = root
             worktree = None
-            if release != current:
+            if not development_current or release != current:
                 worktree = checkout_root / release
                 run_git(root, ["worktree", "add", "--detach", str(worktree), entry["source_ref"]])
                 source_root = worktree
@@ -74,11 +86,22 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1])
     parser.add_argument("--site-root", type=Path, default=Path("build/docs-site"))
     parser.add_argument("--offline-dir", type=Path)
+    build_mode = parser.add_mutually_exclusive_group()
+    build_mode.add_argument(
+        "--development-current",
+        action="store_true",
+        help="Build the declared current version from this checkout (the default); historical versions use source_ref tags.",
+    )
+    build_mode.add_argument(
+        "--released",
+        action="store_true",
+        help="Build every declared version from its immutable source_ref; required for published release documentation.",
+    )
     args = parser.parse_args()
     root = args.root.resolve()
     site_root = args.site_root if args.site_root.is_absolute() else root / args.site_root
     offline_dir = args.offline_dir if args.offline_dir is None or args.offline_dir.is_absolute() else root / args.offline_dir
-    build_all(root, site_root, offline_dir)
+    build_all(root, site_root, offline_dir, development_current=not args.released)
     return 0
 
 

--- a/tools/test_build_all_docs.py
+++ b/tools/test_build_all_docs.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -17,6 +18,45 @@ from build_all_docs import build_all  # noqa: E402
 
 
 class BuildAllDocsTests(unittest.TestCase):
+    @staticmethod
+    def git(root: Path, *arguments: str) -> None:
+        subprocess.run(["git", "-C", str(root), *arguments], check=True, text=True, capture_output=True)
+
+    @staticmethod
+    def write_release_source(root: Path, body: str, banner: str) -> None:
+        source = root / "docs"
+        source.mkdir(exist_ok=True)
+        (source / "index.md").write_text(f"# Documentation\n\n{body}\n", encoding="utf-8")
+        (source / "layout.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 2,
+                    "release": "1.9.2",
+                    "site_title": "StringKit-FP documentation",
+                    "description": "Temporary documentation fixture.",
+                    "required_pages": ["index.md"],
+                    "navigation": [{"title": "Getting Started", "pages": [{"path": "index.md", "title": "Introduction"}]}],
+                    "homepage": {"banner": {"project_path": "assets/banner.svg", "alt": "Temporary banner"}},
+                }
+            ),
+            encoding="utf-8",
+        )
+        (source / "versions.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "current": "1.9.2",
+                    "site_url": "https://example.invalid/stringkit-fp",
+                    "repository_url": "https://github.com/example/stringkit-fp",
+                    "versions": [{"release": "1.9.2", "source_ref": "v1.9.2"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        assets = root / "assets"
+        assets.mkdir(exist_ok=True)
+        (assets / "banner.svg").write_text(banner, encoding="utf-8")
+
     def test_builds_the_current_release_without_a_git_worktree(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -42,6 +82,36 @@ class BuildAllDocsTests(unittest.TestCase):
             self.assertEqual(1, count)
             self.assertTrue((root / "site" / "1.9.1" / "index.html").is_file())
             self.assertTrue((root / "artifacts" / "stringkit-fp-docs-1.9.1.zip").is_file())
+
+    def test_released_mode_reads_current_docs_and_assets_from_the_declared_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.git(root, "init")
+            self.git(root, "config", "user.email", "docs@example.invalid")
+            self.git(root, "config", "user.name", "Documentation tests")
+            self.write_release_source(root, "Released documentation reference.", "<svg>released-banner</svg>")
+            self.git(root, "add", ".")
+            self.git(root, "commit", "-m", "Release documentation")
+            self.git(root, "tag", "v1.9.2")
+
+            self.write_release_source(root, "Development documentation reference.", "<svg>development-banner</svg>")
+            self.git(root, "add", ".")
+            self.git(root, "commit", "-m", "Development documentation")
+
+            released_site = root / "released-site"
+            self.assertEqual(1, build_all(root, released_site, development_current=False))
+            released_html = (released_site / "1.9.2" / "index.html").read_text(encoding="utf-8")
+            released_banner = (released_site / "1.9.2" / "assets" / "homepage-banner.svg").read_text(encoding="utf-8")
+            self.assertIn("Released documentation reference.", released_html)
+            self.assertNotIn("Development documentation reference.", released_html)
+            self.assertEqual("<svg>released-banner</svg>", released_banner)
+
+            development_site = root / "development-site"
+            self.assertEqual(1, build_all(root, development_site, development_current=True))
+            development_html = (development_site / "1.9.2" / "index.html").read_text(encoding="utf-8")
+            development_banner = (development_site / "1.9.2" / "assets" / "homepage-banner.svg").read_text(encoding="utf-8")
+            self.assertIn("Development documentation reference.", development_html)
+            self.assertEqual("<svg>development-banner</svg>", development_banner)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- build published documentation only from immutable source_ref tags while preserving an explicit development preview mode\n- cover tagged document and SVG asset provenance with a regression test\n- document the Pages contract and record post-v1.9.2 documentation changes under Unreleased\n- remove verified merged remote branches and enable automatic branch deletion after merge\n\n## Verification\n- python tools/test_build_docs.py\n- python tools/test_build_all_docs.py\n- python tools/test_check_built_docs.py\n- python tools/test_check_docs.py\n- python tools/check_docs.py\n- python tools/test_docs_examples.py --build-dir build/pre-v1.9.3-final/docs-examples\n- released and development uild_all_docs.py builds plus check_built_docs.py\n- FPCUnit: 159 tests, 0 failures\n- Lazarus package and representative feature-flag example compilation