### PR TITLE
Preserve historical documentation in the version selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added the generated StringKit-FP homepage SVG banner and refined its width for readable alignment with the documentation content.
 - Made published, versioned documentation rebuild every release from the immutable `source_ref` declared in `docs/versions.json`; development builds continue to preview the current checkout explicitly.
+- Extended the documentation version selector with the full tagged history (`1.9.0`, `1.8.1`, `1.8.0`, `1.7.0`, and `1.0.0`), building each release only from the Markdown that existed in its own Git tag.
+- Added legacy-layout support so historical releases without a modern `layout.json` render their preserved Markdown with automatically derived navigation and, when no `index.md` exists, a minimal generated landing page linking to that release's real documents.
+- Hardened release validation: `build_all_docs.py` now fails clearly when any declared `source_ref` does not resolve, and `check_built_docs.py` verifies newest-to-oldest ordering, unique releases, current-release membership, and per-release `source_ref` agreement.
 
 ## [1.9.2] - 2026-08-22
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,10 @@ We especially welcome documentation improvements:
 - Add missing documentation
 - Translate documentation
 
+### Versioned documentation policy
+
+Versioned documentation preserves the documentation that existed at each historical release. Older releases may therefore contain fewer pages than newer releases. Each declared version in `docs/versions.json` is rebuilt from its immutable `source_ref` tag; never copy current documentation into an older release or edit historical tags.
+
 ## ⭐ Recognition
 
 Contributors will be recognized in:

--- a/docs/versions.json
+++ b/docs/versions.json
@@ -11,6 +11,26 @@
     {
       "release": "1.9.1",
       "source_ref": "v1.9.1"
+    },
+    {
+      "release": "1.9.0",
+      "source_ref": "v1.9.0"
+    },
+    {
+      "release": "1.8.1",
+      "source_ref": "v1.8.1"
+    },
+    {
+      "release": "1.8.0",
+      "source_ref": "v1.8.0"
+    },
+    {
+      "release": "1.7.0",
+      "source_ref": "v1.7.0"
+    },
+    {
+      "release": "1.0.0",
+      "source_ref": "v1.0.0"
     }
   ]
 }

--- a/tools/build_all_docs.py
+++ b/tools/build_all_docs.py
@@ -34,6 +34,16 @@ def run_git(root: Path, arguments: list[str]) -> None:
         raise RuntimeError(f"git {' '.join(arguments)} failed:\n{result.stdout}{result.stderr}")
 
 
+def git_ref_resolves(root: Path, ref: str) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(root), "rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
 def build_all(
     root: Path,
     site_root: Path,
@@ -50,6 +60,13 @@ def build_all(
     root = root.resolve()
     versions_path = root / "docs" / "versions.json"
     current, versions = load_versions(versions_path)
+    unresolvable = [
+        f"{entry['release']} -> {entry['source_ref']}"
+        for entry in versions
+        if not (development_current and entry["release"] == current) and not git_ref_resolves(root, entry["source_ref"])
+    ]
+    if unresolvable:
+        raise ValueError(f"source_ref(s) do not resolve to a commit: {', '.join(unresolvable)}")
     page_count = 0
     with tempfile.TemporaryDirectory(prefix="stringkit-fp-docs-") as temporary:
         checkout_root = Path(temporary)

--- a/tools/build_docs.py
+++ b/tools/build_docs.py
@@ -211,8 +211,29 @@ def legacy_navigation(source: Path) -> tuple[NavigationSection, ...]:
     return tuple(NavigationSection(title, tuple(pages)) for title, pages in grouped.items() if pages)
 
 
+def legacy_layout(source: Path) -> DocumentationLayout:
+    """Describe a historical release that predates documentation layouts.
+
+    Navigation is derived only from the Markdown files that exist in the
+    historical source so sparse releases stay historically accurate.
+    """
+    documents = sorted(path.relative_to(source).as_posix() for path in source.rglob("*.md"))
+    if not documents:
+        raise ValueError(f"no Markdown documents found in {source}")
+    return DocumentationLayout(
+        "StringKit-FP documentation",
+        "Practical StringKit-FP documentation for Free Pascal and Lazarus.",
+        legacy_navigation(source),
+        tuple(),
+        {},
+        legacy=True,
+    )
+
+
 def load_layout(source: Path, config: SiteConfig) -> DocumentationLayout:
     layout_path = source / "layout.json"
+    if not layout_path.is_file():
+        return legacy_layout(source)
     try:
         data = json.loads(layout_path.read_text(encoding="utf-8"))
         schema = data.get("schema_version")
@@ -541,6 +562,26 @@ def remove_first_heading(body: str) -> str:
     return re.sub(r"^<h1\b[^>]*>.*?</h1>\n?", "", body, count=1, flags=re.DOTALL)
 
 
+def landing_content(layout: DocumentationLayout, page: Path, output: Path, config: SiteConfig) -> RenderedDocument:
+    """Build a minimal landing shell that links to this release's real pages.
+
+    Used only when a historical release shipped no ``index.md`` so no historical
+    content is invented.
+    """
+    items = "".join(
+        f'<li><a href="{html.escape(nav_href(page, output, item.path), quote=True)}">{html.escape(item.title)}</a></li>'
+        for item in layout.pages
+    )
+    body = (
+        '<section><h2 id="documentation-in-this-release">Documentation in this release</h2>'
+        f"<p>StringKit-FP {html.escape(config.release)} documentation preserved from the "
+        f"<code>{html.escape(config.source_ref)}</code> source snapshot.</p>"
+        f"<ul>{items}</ul></section>"
+    )
+    text = plain_markdown(f"Documentation in this release StringKit-FP {config.release} documentation")
+    return RenderedDocument(body, tuple(), text)
+
+
 def page_shell(title: str, rendered: RenderedDocument, config: SiteConfig, layout: DocumentationLayout, current: NavigationPage | None, page: Path, output: Path, relative: str) -> str:
     stylesheet = relative_url(page.parent, output / "assets" / "site.css"); script = relative_url(page.parent, output / "assets" / "site.js"); search_script = relative_url(page.parent, output / "search-index.js")
     home = relative == "index.md"; body = remove_first_heading(rendered.body) if home else rendered.body
@@ -613,14 +654,23 @@ def build_site(source: Path, output: Path, site_root: Path, versions_path: Path,
         raise ValueError(f"no Markdown documents found in {source}")
     validate_source_links(source, documents, source.parent); prepare_output(output, config.release); copy_assets(output, source.parent, layout)
     search_entries: list[dict[str, object]] = []; by_path = {item.path: item for item in layout.pages}
+    has_home = False
     for document in documents:
-        relative = document.relative_to(source); relative_path = relative.as_posix(); page = output / relative.with_suffix(".html"); page.parent.mkdir(parents=True, exist_ok=True)
+        relative = document.relative_to(source); relative_path = relative.as_posix()
+        if relative_path == "index.md":
+            has_home = True
+        page = output / relative.with_suffix(".html"); page.parent.mkdir(parents=True, exist_ok=True)
         rendered = markdown_to_html(document.read_text(encoding="utf-8"), link_resolver(document, page, source, output, source.parent, config))
         fallback = by_path.get(relative_path, NavigationPage(relative_path, relative.stem, "Documentation"))
         title = next((text for level, text, _identifier in rendered.headings if level == 1), fallback.title)
         page.write_text(page_shell(title, rendered, config, layout, by_path.get(relative_path), page, output, relative_path), encoding="utf-8")
         item = by_path.get(relative_path)
         search_entries.append({"title": title, "section": item.section if item else "Documentation", "headings": [text for level, text, _identifier in rendered.headings if level >= 2], "url": relative.with_suffix(".html").as_posix(), "text": rendered.text})
+    if not has_home:
+        landing = output / "index.html"
+        rendered_landing = landing_content(layout, landing, output, config)
+        title = f"StringKit-FP {config.release} documentation"
+        landing.write_text(page_shell(title, rendered_landing, config, layout, None, landing, output, "index.md"), encoding="utf-8")
     search_json = json.dumps(search_entries, ensure_ascii=False, separators=(",", ":"))
     (output / "search-index.json").write_text(json.dumps(search_entries, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
     (output / "search-index.js").write_text("globalThis.StringKitSearchIndex=" + search_json.replace("<", "\\u003c").replace(">", "\\u003e").replace("&", "\\u0026") + ";\n", encoding="utf-8")

--- a/tools/check_built_docs.py
+++ b/tools/check_built_docs.py
@@ -100,15 +100,33 @@ def check_page(page: Path, site: Path, release: str) -> list[str]:
     return errors
 
 
+def release_order_key(value: str) -> tuple[int, ...]:
+    try:
+        return tuple(int(part) for part in value.split("."))
+    except ValueError as exc:
+        raise ValueError(f"release {value!r} must use numeric dot-separated segments") from exc
+
+
 def check_site(site: Path) -> list[str]:
     site = site.resolve()
     errors: list[str] = []
+    releases: list[str] = []
+    declared_refs: dict[str, str] = {}
     try:
         manifest = json.loads((site / "versions.json").read_text(encoding="utf-8"))
         current = str(manifest["current"])
         entries = manifest["versions"]
         if not isinstance(entries, list) or not entries:
             raise ValueError("versions must be a non-empty list")
+        releases = [str(entry["release"]) for entry in entries]
+        duplicates = sorted({release for release in releases if releases.count(release) > 1})
+        if duplicates:
+            raise ValueError(f"duplicate release entries: {', '.join(duplicates)}")
+        if releases != sorted(releases, key=release_order_key, reverse=True):
+            raise ValueError("versions must be ordered newest to oldest")
+        if current not in releases:
+            raise ValueError(f"current release {current!r} is absent from versions")
+        declared_refs = {str(entry["release"]): str(entry["source_ref"]) for entry in entries}
     except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
         return [f"{site / 'versions.json'}: invalid version metadata: {exc}"]
     landing = site / "index.html"
@@ -124,6 +142,8 @@ def check_site(site: Path) -> list[str]:
             identity = json.loads((directory / "release.json").read_text(encoding="utf-8"))
             if identity.get("release") != release or not identity.get("source_ref"):
                 raise ValueError("release/source_ref identity mismatch")
+            if identity.get("source_ref") != declared_refs.get(release):
+                raise ValueError("built source_ref differs from the declared metadata")
             indexed = json.loads((directory / "search-index.json").read_text(encoding="utf-8"))
             if not isinstance(indexed, list) or not indexed:
                 raise ValueError("search index must be a non-empty list")

--- a/tools/test_build_all_docs.py
+++ b/tools/test_build_all_docs.py
@@ -15,6 +15,7 @@ TOOLS = Path(__file__).resolve().parent
 sys.path.insert(0, str(TOOLS))
 
 from build_all_docs import build_all  # noqa: E402
+from check_built_docs import check_site  # noqa: E402
 
 
 class BuildAllDocsTests(unittest.TestCase):
@@ -112,6 +113,112 @@ class BuildAllDocsTests(unittest.TestCase):
             development_banner = (development_site / "1.9.2" / "assets" / "homepage-banner.svg").read_text(encoding="utf-8")
             self.assertIn("Development documentation reference.", development_html)
             self.assertEqual("<svg>development-banner</svg>", development_banner)
+
+    def write_manifest(self, root: Path, current: str, versions: list[dict[str, str]]) -> None:
+        source = root / "docs"
+        (source / "versions.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "current": current,
+                    "site_url": "https://example.invalid/stringkit-fp",
+                    "repository_url": "https://github.com/example/stringkit-fp",
+                    "versions": versions,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_reports_unresolvable_source_refs_before_building(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.git(root, "init")
+            self.git(root, "config", "user.email", "docs@example.invalid")
+            self.git(root, "config", "user.name", "Documentation tests")
+            source = root / "docs"
+            source.mkdir()
+            (source / "index.md").write_text("# Documentation\n", encoding="utf-8")
+            (source / "layout.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "release": "1.9.2",
+                        "site_title": "StringKit-FP documentation",
+                        "description": "Temporary documentation fixture.",
+                        "required_pages": ["index.md"],
+                        "navigation": [{"title": "Getting Started", "pages": [{"path": "index.md", "title": "Introduction"}]}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            self.write_manifest(root, "1.9.2", [{"release": "1.9.2", "source_ref": "v1.9.2"}, {"release": "1.9.1", "source_ref": "v1.9.1"}])
+            self.git(root, "add", ".")
+            self.git(root, "commit", "-m", "Release documentation")
+            self.git(root, "tag", "v1.9.2")
+
+            with self.assertRaisesRegex(ValueError, "do not resolve to a commit.*v1\.9\.1"):
+                build_all(root, root / "site", development_current=False)
+            self.assertFalse((root / "site").exists())
+
+    def test_released_mode_builds_legacy_tags_without_a_layout_json(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.git(root, "init")
+            self.git(root, "config", "user.email", "docs@example.invalid")
+            self.git(root, "config", "user.name", "Documentation tests")
+            manifest = [{"release": "1.9.2", "source_ref": "v1.9.2"}, {"release": "1.8.0", "source_ref": "v1.8.0"}]
+
+            source = root / "docs"
+            source.mkdir()
+            (source / "cheat-sheet.md").write_text("# Historical Cheat Sheet\n\nhistorical-cheat-marker\n", encoding="utf-8")
+            self.write_manifest(root, "1.9.2", manifest)
+            self.git(root, "add", ".")
+            self.git(root, "commit", "-m", "Legacy documentation")
+            self.git(root, "tag", "v1.8.0")
+
+            (source / "cheat-sheet.md").unlink()
+            (source / "index.md").write_text("# Modern introduction\n\nmodern-intro-marker\n", encoding="utf-8")
+            (source / "layout.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": 2,
+                        "release": "1.9.2",
+                        "site_title": "StringKit-FP documentation",
+                        "description": "Temporary documentation fixture.",
+                        "required_pages": ["index.md"],
+                        "navigation": [{"title": "Getting Started", "pages": [{"path": "index.md", "title": "Introduction"}]}],
+                        "project": [{"title": "GitHub repository", "url": "https://github.com/example/stringkit-fp"}],
+                        "homepage": {
+                            "tagline": "Temporary tagline.",
+                            "banner": {"project_path": "assets/banner.svg", "alt": "Temporary banner"},
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            assets = root / "assets"
+            assets.mkdir(exist_ok=True)
+            (assets / "banner.svg").write_text("<svg>released-banner</svg>", encoding="utf-8")
+            self.write_manifest(root, "1.9.2", manifest)
+            self.git(root, "add", ".")
+            self.git(root, "commit", "-m", "Modern documentation")
+            self.git(root, "tag", "v1.9.2")
+
+            released_site = root / "released-site"
+            build_all(root, released_site, development_current=False)
+
+            historical_cheat = (released_site / "1.8.0" / "cheat-sheet.html").read_text(encoding="utf-8")
+            self.assertIn("historical-cheat-marker", historical_cheat)
+            historical_landing = (released_site / "1.8.0" / "index.html").read_text(encoding="utf-8")
+            self.assertIn('href="cheat-sheet.html"', historical_landing)
+            self.assertNotIn("modern-intro-marker", historical_landing)
+            modern_home = (released_site / "1.9.2" / "index.html").read_text(encoding="utf-8")
+            self.assertIn("modern-intro-marker", modern_home)
+            self.assertEqual("<svg>released-banner</svg>", (released_site / "1.9.2" / "assets" / "homepage-banner.svg").read_text(encoding="utf-8"))
+            for page in (released_site / "1.8.0").rglob("*.html"):
+                self.assertNotIn("modern-intro-marker", page.read_text(encoding="utf-8"), page)
+                self.assertIn('value="../1.9.2/index.html"', page.read_text(encoding="utf-8"), page)
+            self.assertEqual([], check_site(released_site))
 
 
 if __name__ == "__main__":

--- a/tools/test_build_docs.py
+++ b/tools/test_build_docs.py
@@ -203,6 +203,102 @@ class BuildDocsTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "not declared"):
                 build_site(source, output, site_root, source / "versions.json", release="2.0.0")
 
+    @staticmethod
+    def write_legacy_fixture(root: Path, documents: dict[str, str]) -> tuple[Path, Path, Path]:
+        source = root / "docs"
+        output = root / "site" / "1.8.0"
+        site_root = output.parent
+        source.mkdir(parents=True)
+        for name, body in documents.items():
+            (source / name).write_text(body, encoding="utf-8")
+        versions = source / "versions.json"
+        versions.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "current": "1.9.1",
+                    "site_url": "https://example.invalid/stringkit-fp",
+                    "repository_url": "https://github.com/example/stringkit-fp",
+                    "versions": [
+                        {"release": "1.9.1", "source_ref": "v1.9.1"},
+                        {"release": "1.8.0", "source_ref": "v1.8.0"},
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return source, output, site_root
+
+    def test_builds_a_legacy_release_without_a_layout_json(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source, output, site_root = self.write_legacy_fixture(
+                Path(directory),
+                {
+                    "cheat-sheet.md": "# Historical Cheat Sheet\n\nSparse historical reference.\n",
+                    "helper-coverage.md": "# Historical Helper Coverage\n\nSparse historical inventory.\n",
+                },
+            )
+
+            build_site(source, output, site_root, source / "versions.json", release="1.8.0")
+
+            generated = sorted(path.relative_to(output).as_posix() for path in output.rglob("*.html"))
+            self.assertEqual(["cheat-sheet.html", "helper-coverage.html", "index.html"], generated)
+            landing = (output / "index.html").read_text(encoding="utf-8")
+            self.assertIn("Documentation in this release", landing)
+            self.assertIn('href="cheat-sheet.html"', landing)
+            self.assertIn('href="helper-coverage.html"', landing)
+            self.assertIn("preserved from the", landing)
+            cheat_sheet = (output / "cheat-sheet.html").read_text(encoding="utf-8")
+            self.assertIn("Historical Cheat Sheet", cheat_sheet)
+            self.assertIn(">Documentation<", cheat_sheet)
+            identity = json.loads((output / "release.json").read_text(encoding="utf-8"))
+            self.assertEqual("1.8.0", identity["release"])
+            self.assertEqual("v1.8.0", identity["source_ref"])
+
+    def test_historical_pages_do_not_include_other_release_documentation(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source, output, site_root = self.write_legacy_fixture(
+                Path(directory),
+                {"cheat-sheet.md": "# Historical Cheat Sheet\n\nOnly historical content here.\n"},
+            )
+
+            build_site(source, output, site_root, source / "versions.json", release="1.8.0")
+
+            for page in output.rglob("*.html"):
+                self.assertNotIn("Beginner Guide", page.read_text(encoding="utf-8"), page)
+
+    def test_sparse_single_document_legacy_release_builds(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source, output, site_root = self.write_legacy_fixture(
+                Path(directory),
+                {"cheat-sheet.md": "# Historical Cheat Sheet\n\nThe only historical document.\n"},
+            )
+
+            count = build_site(source, output, site_root, source / "versions.json", release="1.8.0")
+
+            self.assertEqual(1, count)
+            landing = (output / "index.html").read_text(encoding="utf-8")
+            self.assertIn('href="cheat-sheet.html"', landing)
+            self.assertNotIn('href="helper-coverage.html"', landing)
+
+    def test_selector_declares_history_and_marks_the_current_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            source, _output, site_root = self.write_legacy_fixture(
+                Path(directory),
+                {"cheat-sheet.md": "# Historical Cheat Sheet\n\nHistorical.\n"},
+            )
+            versions = source / "versions.json"
+
+            build_site(source, site_root / "1.9.1", site_root, versions, release="1.9.1")
+            build_site(source, site_root / "1.8.0", site_root, versions, release="1.8.0")
+
+            page = (site_root / "1.9.1" / "cheat-sheet.html").read_text(encoding="utf-8")
+            self.assertIn('<option value="index.html" selected>v1.9.1 (current)</option>', page)
+            self.assertIn('<option value="../1.8.0/index.html">v1.8.0</option>', page)
+            historical_page = (site_root / "1.8.0" / "cheat-sheet.html").read_text(encoding="utf-8")
+            self.assertIn('value="../1.9.1/index.html"', historical_page)
+            self.assertIn('<option value="index.html" selected>v1.8.0</option>', historical_page)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/test_check_built_docs.py
+++ b/tools/test_check_built_docs.py
@@ -74,6 +74,51 @@ class CheckBuiltDocsTests(unittest.TestCase):
             errors = check_site(site)
             self.assertTrue(any("missing required asset" in error for error in errors))
 
+    def rewrite_manifest(self, site: Path, versions: list[dict[str, str]], current: str = "1.9.1") -> None:
+        (site / "versions.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "current": current,
+                    "site_url": "https://example.invalid/stringkit-fp",
+                    "repository_url": "https://github.com/example/stringkit-fp",
+                    "versions": versions,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_reports_versions_ordered_other_than_newest_to_oldest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            site = self.build_fixture(Path(directory))
+            self.rewrite_manifest(site, [{"release": "1.8.0", "source_ref": "v1.8.0"}, {"release": "1.9.1", "source_ref": "v1.9.1"}])
+            self.assertTrue(any("ordered newest to oldest" in error for error in check_site(site)))
+
+    def test_reports_duplicate_release_entries(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            site = self.build_fixture(Path(directory))
+            self.rewrite_manifest(site, [{"release": "1.9.1", "source_ref": "v1.9.1"}, {"release": "1.9.1", "source_ref": "v1.9.1"}])
+            self.assertTrue(any("duplicate release entries" in error for error in check_site(site)))
+
+    def test_reports_a_current_release_missing_from_versions(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            site = self.build_fixture(Path(directory))
+            self.rewrite_manifest(
+                site,
+                [{"release": "1.9.0", "source_ref": "v1.9.0"}, {"release": "1.8.0", "source_ref": "v1.8.0"}],
+                current="1.9.1",
+            )
+            self.assertTrue(any("absent from versions" in error for error in check_site(site)))
+
+    def test_reports_a_built_source_ref_that_differs_from_the_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            site = self.build_fixture(Path(directory))
+            identity = site / "1.9.1" / "release.json"
+            release = json.loads(identity.read_text(encoding="utf-8"))
+            release["source_ref"] = "v9.9.9"
+            identity.write_text(json.dumps(release), encoding="utf-8")
+            self.assertTrue(any("differs from the declared metadata" in error for error in check_site(site)))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Extend the versioned documentation site to the full tagged history so the version selector behaves like a time machine, matching the ChronoKit-FP approach.

- Extend \docs/versions.json\ with \1.9.0\, \1.8.1\, \1.8.0\, \1.7.0\, and \1.0.0\ (all real tags; newest to oldest)
- Auto-derive navigation for legacy releases that predate \layout.json\ from only the Markdown in their own tag
- Generate a minimal landing page when a release shipped no \index.md\, linking only to that release's real documents
- Pre-flight every declared \source_ref\ with \git rev-parse\ and fail clearly when it does not resolve
- Validate newest-to-oldest ordering, unique releases, current-release membership, and per-release \source_ref\ agreement in built sites
- Document the versioned documentation policy in CONTRIBUTING.md

**Historical accuracy principle:** each release is built from its immutable Git tag; no current documentation is copied into old releases and sparse historical documentation is intentional (v1.0.0 renders exactly one cheat-sheet page).

**No UI redesign:** current modern releases keep their existing navigation hierarchy, typography, theme selector, search, banner, and page shell unchanged.

## Test plan

- [x] \	ools/test_build_docs.py\ — 11 tests incl. legacy build without layout.json, sparse single-document release, selector history/current marking
- [x] \	ools/test_build_all_docs.py\ — 4 tests incl. unresolvable source_ref failure and mixed-era released-mode worktree build
- [x] \	ools/test_check_built_docs.py\ — 8 tests incl. ordering, duplicates, absent current, tampered source_ref
- [x] \	ools/test_check_docs.py\, \	ools/check_docs.py\, \	ools/test_docs_examples.py\
- [x] Full released-mode multi-version build: 7 paths / 41 pages
- [x] \check_built_docs.py\ passes on both released and development-preview sites; every version-selector target resolves